### PR TITLE
added logging for Finnhub interactions

### DIFF
--- a/src/main/java/org/galatea/starter/entrypoint/FinnhubRestController.java
+++ b/src/main/java/org/galatea/starter/entrypoint/FinnhubRestController.java
@@ -9,11 +9,13 @@ import net.sf.aspect4log.Log.Level;
 import org.galatea.starter.domain.FinnhubQuote;
 import org.galatea.starter.domain.FinnhubSymbol;
 import org.galatea.starter.service.FinnhubService;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 
 @Slf4j
 @Log(enterLevel = Level.INFO, exitLevel = Level.INFO)

--- a/src/main/java/org/galatea/starter/service/FinnhubService.java
+++ b/src/main/java/org/galatea/starter/service/FinnhubService.java
@@ -1,16 +1,20 @@
 package org.galatea.starter.service;
 
+import java.math.BigDecimal;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 
+import feign.Response;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.galatea.starter.domain.FinnhubQuote;
 import org.galatea.starter.domain.FinnhubQuoteEntity;
 import org.galatea.starter.domain.FinnhubSymbol;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 
 /**
  * A layer for transformation, aggregation, and business required when retrieving data from Finnhub.
@@ -37,14 +41,49 @@ public class FinnhubService {
     }
 
     public FinnhubQuote getQuote(String symbol) {
-        FinnhubQuoteEntity cached = repository.findById(symbol).orElse(null);
 
-        //Return cached entry if not stale
+        FinnhubQuoteEntity cached = repository.findById(symbol).orElse(null);
+        FinnhubQuote apiQuote = null;
+
+        //1. Returned cached data if not stale
         if (cached != null && Instant.now().isBefore(cached.getCachedAt().plus(CACHE_TTL))) {
+            log.info("Retrieved quote from cache: {}", cached.getQuote());
             return cached.getQuote();
         }
 
-        FinnhubQuote apiQuote = finnhubClient.getQuote(symbol);
+        try {
+            //2. Try API
+            apiQuote = finnhubClient.getQuote(symbol);
+
+            //Finnhub will return dummy data with all 0s if the symbol is not found, we want to flag that
+            boolean allZero = apiQuote.getCurrent().compareTo(BigDecimal.ZERO) == 0 &&
+                    apiQuote.getPreviousClose().compareTo(BigDecimal.ZERO) == 0 &&
+                    apiQuote.getHigh().compareTo(BigDecimal.ZERO) == 0 &&
+                    apiQuote.getLow().compareTo(BigDecimal.ZERO) == 0 &&
+                    apiQuote.getOpen().compareTo(BigDecimal.ZERO) == 0;
+
+            //3. Ensure data received is legit
+            if(allZero) {
+                log.error("Finnhub returned no data for symbol: " + symbol);
+                throw new ResponseStatusException(
+                        HttpStatus.BAD_REQUEST,
+                        "Finnhub returned no data for symbol: " + symbol
+                );
+            }
+
+            log.info("Retrieved quote from Finnhub: {}", apiQuote);
+        } catch (ResponseStatusException e) {
+            //Pass through known symbol error
+            throw e;
+        } catch (Exception e) {
+            //4. API didn't work. Throw error
+            log.error("Failed to retrieve quote from Finnhub", e);
+            throw new ResponseStatusException(
+                    HttpStatus.SERVICE_UNAVAILABLE,
+                    "Failed to retrieve quote from Finnhub for " + symbol, e
+            );
+        }
+
 
         FinnhubQuoteEntity entity = FinnhubQuoteEntity.builder()
                 .symbolID(symbol)


### PR DESCRIPTION
- Added logging and error messaging for Finnhub interactions
- Sends 400 if requested symbol has no data (and logs it)
- Sends 503 if Finnhub returns an error (and logs it)
- Logs cache hits
- Logs API pulls
Right now when we throw HTTP status errors it returns the white label error page in the browser. I'm led to believe that if we do a GET request to our API and it's an error, it does send the JSON for the error (correct me if I am wrong though). I think this is expected behavior but if we want an exception handler to reformat it to JSON for the browser view we can do that too. 